### PR TITLE
Fix wrong status of few entries

### DIFF
--- a/aws_status/feed.py
+++ b/aws_status/feed.py
@@ -10,12 +10,12 @@ STATUS_UNKNOWN = 3
 
 def get_status(title, description):
     if title.startswith("Service is operating normally") \
-       or title.startswith("Informational message: [RESOLVED]") \
-       or title.startswith("Informational message: [Resolved]") \
+       or '[RESOLVED]' in title \
+       or '[Resolved]' in title \
        or re.search("he service is (now )?operating normally.?\n?", description) \
        or title.startswith("OK"):
         status = STATUS_OK
-    elif title.startswith("Informational message") or title.startswith("Performanceissues"):
+    elif title.startswith("Informational message") or title.startswith("Performance issues"):
         status = STATUS_WARNING
     elif title.startswith("Service disruption"):
         status = STATUS_CRITICAL


### PR DESCRIPTION
This PR change two thing:
* There was a missing space in "Performance issues".
* Consider OK as soon as "[RESOLVED]" or "[Resolved]" is in the title. No longer limit this to Informational message.

The last point fix false warning for entry like "Performance issues: [RESOLVED] Elevated error rates" / "The service has recovered. Error rates and latencies have returned to normal levels."
Entry taken from http://status.aws.amazon.com/rss/sqs-sa-east-1.rss