### PR TITLE
Follow AWS region rename: us-standard => us-east-1

### DIFF
--- a/aws_status/feed.py
+++ b/aws_status/feed.py
@@ -44,6 +44,8 @@ class Feed(object):
         if match:
             self.service = match.group(1)
             self.region = match.group(2)
+            if self.region == 'us-standard':
+                self.region = 'us-east-1'
         #special case: services with no region
         #ex: route53, or management-console
         else:

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -9,7 +9,7 @@ class TestFeed(unittest.TestCase):
         self.assertEqual(feed.region, "us-east-1")
         feed = Feed("https://amazon.status.page/rss/this-is-a-service-us-standard.rss")
         self.assertEqual(feed.service, "this-is-a-service")
-        self.assertEqual(feed.region, "us-standard")
+        self.assertEqual(feed.region, "us-east-1")
 
     def test_service_and_region_extraction_special_case(self):
         feed = Feed("https://amazon.status.page/rss/this-is-a-service-with-no-region.rss")


### PR DESCRIPTION
One of the S3 RSS feed use the us-standard region. According to [AWS documentation](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) this region is now renamed us-east-1

> Amazon S3 renamed the US Standard Region to the US East (N. Virginia) Region

This PR change the region returned by Feed object to follow this rename and use "us-east-1" instead of "us-standard".